### PR TITLE
allow to set custom expires_in

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ should be cached, similar to how you use them with `before_action`.
 
 As of Rails 3.0, you can also pass `:expires_in` with a time
 interval (in seconds) to schedule expiration of the cached item.
+You can also modify the expires in by passing a symbol as `:set_expires_in`.
+This is useful if you need different expire times in your action or if you use
+a concern to set `caches_action` and your controllers must have different
+expire times.
 
 The following example depicts some of the points made above:
 
@@ -85,6 +89,9 @@ class ListsController < ApplicationController
 
   # expire cache after an hour
   caches_action :archived, expires_in: 1.hour
+
+  # custom expire cache
+  caches_action :archived, expires_in: :set_expires_in
 
   # cache unless it's a JSON request
   caches_action :index, unless: -> { request.format.json? }
@@ -104,6 +111,14 @@ class ListsController < ApplicationController
         user_list_url(params[:user_id], params[:id])
       else
         list_url(params[:id])
+      end
+    end
+
+    def set_expires_in
+      if params[:user_id]
+        2.hours
+      else
+        48.hours
       end
     end
 end


### PR DESCRIPTION
On apps with controllers that only use the default CRUD actions it is quite common to extract the action caching logic to a concern to be able to the share the same logic between controllers and to reason about the caching strategy in a single place, the concern could be similar to this one:

```
module SetActionCaching
  extend ActiveSupport::Concern

  included do
    caches_action :index, :show,
      cache_path: :cache_path, expires_in: 2.hours, if: :cacheable_action?
  end

  ...
end
```

The issue with this approach is that action caching does not allow to set a custom `expires_in` which force all controllers to use the same expire time, this PR allow to set a custom `expires_in` time using a symbol as `caches_action :index, expires_in: :set_expires_in` or even a custom object which will allow to extract all the logic into the concern. This can be also  useful if different expire times for a single action are needed.